### PR TITLE
refactor(user): simplify AgencyRole constants and fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ linux_386
 /config.yml
 anthropos
 .trae
+PRD_ Wandering Digital.md

--- a/cdt/user.go
+++ b/cdt/user.go
@@ -5,8 +5,7 @@ type AccountType string
 
 const (
 	AccountTypePlatformAdmin AccountType = "platform_admin"
-	AccountTypeAgencyOwner   AccountType = "agency_owner"
-	AccountTypeAgencyStaff   AccountType = "agency_staff"
+	AccountTypeAgent         AccountType = "agent"
 	AccountTypeCustomer      AccountType = "customer"
 )
 
@@ -30,8 +29,7 @@ const (
 func (at AccountType) IsValid() bool {
 	for _, userType := range []AccountType{
 		AccountTypePlatformAdmin,
-		AccountTypeAgencyOwner,
-		AccountTypeAgencyStaff,
+		AccountTypeAgent,
 		AccountTypeCustomer,
 	} {
 		if userType == at {

--- a/cdt/user.go
+++ b/cdt/user.go
@@ -4,8 +4,10 @@ package cdt
 type AccountType string
 
 const (
-	AccountTypeClient AccountType = "client"
-	AccountTypeAgent  AccountType = "agent"
+	AccountTypePlatformAdmin AccountType = "platform_admin"
+	AccountTypeAgencyOwner   AccountType = "agency_owner"
+	AccountTypeAgencyStaff   AccountType = "agency_staff"
+	AccountTypeCustomer      AccountType = "customer"
 )
 
 // AccountStatus represents the status of the user's account
@@ -18,17 +20,20 @@ const (
 	AccountStatusBlocked   AccountStatus = "blocked"
 )
 
-// AgentOrganizationRole represents the role of an agent within their organization
-type AgentOrganizationRole string
+type AgencyRole string
 
 const (
-	AgentOrganizationRoleOwner          AgentOrganizationRole = "owner"
-	AgentOrganizationRoleAdmin          AgentOrganizationRole = "admin"
-	AgentOrganizationRoleRepresentative AgentOrganizationRole = "representative"
+	AgencyRoleOwner AgencyRole = "owner"
+	AgencyRoleStaff AgencyRole = "staff"
 )
 
 func (at AccountType) IsValid() bool {
-	for _, userType := range []AccountType{AccountTypeClient, AccountTypeAgent} {
+	for _, userType := range []AccountType{
+		AccountTypePlatformAdmin,
+		AccountTypeAgencyOwner,
+		AccountTypeAgencyStaff,
+		AccountTypeCustomer,
+	} {
 		if userType == at {
 			return true
 		}
@@ -47,9 +52,9 @@ func (as AccountStatus) IsValid() bool {
 	return false
 }
 
-func (aor AgentOrganizationRole) IsValid() bool {
-	for _, agentOrganizationRole := range []AgentOrganizationRole{AgentOrganizationRoleOwner, AgentOrganizationRoleAdmin, AgentOrganizationRoleRepresentative} {
-		if agentOrganizationRole == aor {
+func (ar AgencyRole) IsValid() bool {
+	for _, agencyRole := range []AgencyRole{AgencyRoleOwner, AgencyRoleStaff} {
+		if agencyRole == ar {
 			return true
 		}
 	}

--- a/cmd/migration/down.go
+++ b/cmd/migration/down.go
@@ -27,5 +27,5 @@ func downDatabase(cmd *cobra.Command, args []string) {
 	err := db.GormDB.Migrator().DropTable(migration.Models...)
 	logDBFatal(err)
 
-	log.Println("Database dopped successfully!")
+	log.Println("Database dropped successfully!")
 }

--- a/cmd/migration/root.go
+++ b/cmd/migration/root.go
@@ -18,7 +18,7 @@ var (
 		Long:  `Migration is a tool to generate and modify databse tables`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := conn.ConnectDB(); err != nil {
-				return fmt.Errorf("Cant't connect database: %v", err)
+				return fmt.Errorf("Can't connect database: %v", err)
 			}
 			return nil
 		},

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -63,7 +63,7 @@ func (r *Redis) Set(ctx context.Context, key string, value string, expiration ..
 	}
 
 	if err := r.client.Set(ctx, key, value, expiry).Err(); err != nil {
-		log.Println("error: %v [set redis cache]", err.Error())
+		log.Printf("error: %v [set redis cache]", err.Error())
 		return err
 	}
 

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -12,5 +12,5 @@ var (
 func init() {
 	// Register models for migration
 
-	Models = append(Models, &model.User{}, &model.Traveller{}, &model.Organization{}, &model.Agent{}, &model.TemporarySignupInfo{})
+	Models = append(Models, &model.User{}, &model.Customer{}, &model.Agency{}, &model.AgencyStaff{}, &model.TemporarySignupInfo{})
 }

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -12,5 +12,5 @@ var (
 func init() {
 	// Register models for migration
 
-	Models = append(Models, &model.User{}, &model.Customer{}, &model.Agency{}, &model.AgencyStaff{}, &model.TemporarySignupInfo{})
+	Models = []interface{}{&model.User{}, &model.Customer{}, &model.Agency{}, &model.Agent{}, &model.TemporarySignupInfo{}}
 }

--- a/model/user.go
+++ b/model/user.go
@@ -10,81 +10,81 @@ import (
 
 type (
 	User struct {
-		ID          uint              `gorm:"primaryKey" json:"id"`
-		Email       string            `gorm:"not null;type:varchar(100)" json:"email"`
-		Password    string            `gorm:"not null;type:varchar(100)" json:"-"`
-		AccountType cdt.AccountType   `gorm:"not null;type:varchar(20)" json:"account_type"`
-		Status      cdt.AccountStatus `gorm:"not null;type:varchar(30)" json:"status"`
+		ID          uint              `gorm:"column:id;primaryKey" json:"id"`
+		Email       string            `gorm:"column:email;not null;type:varchar(100)" json:"email"`
+		Password    string            `gorm:"column:password;not null;type:varchar(100)" json:"-"`
+		AccountType cdt.AccountType   `gorm:"column:account_type;not null;type:varchar(20)" json:"account_type"`
+		Status      cdt.AccountStatus `gorm:"column:status;not null;type:varchar(30)" json:"status"`
 
-		CreatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
-		UpdatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
+		CreatedAt time.Time `gorm:"column:created_at;not null;type:timestamptz" json:"-"`
+		UpdatedAt time.Time `gorm:"column:updated_at;not null;type:timestamptz" json:"-"`
 		DeletedAt gorm.DeletedAt
 	}
 
 	Customer struct {
-		ID      uint   `gorm:"primaryKey" json:"-"`
-		UserID  uint   `gorm:"not null;type:int8" json:"user_id"`
-		Name    string `gorm:"not null;type:varchar(150)" json:"name"`
-		Photo   string `gorm:"not null; type:varchar(100)" json:"photo"`
-		Address string `gorm:"not null;type:varchar(250)" json:"address"`
+		ID      uint   `gorm:"column:id;primaryKey" json:"-"`
+		UserID  uint   `gorm:"column:user_id;not null;type:int8" json:"user_id"`
+		Name    string `gorm:"column:name;not null;type:varchar(150)" json:"name"`
+		Photo   string `gorm:"column:photo;not null; type:varchar(100)" json:"photo"`
+		Address string `gorm:"column:address;not null;type:varchar(250)" json:"address"`
 
-		CreatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
-		UpdatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
+		CreatedAt time.Time `gorm:"column:created_at;not null;type:timestamptz" json:"-"`
+		UpdatedAt time.Time `gorm:"column:updated_at;not null;type:timestamptz" json:"-"`
 		DeletedAt gorm.DeletedAt
 
 		User User `gorm:"foreignKey:user_id" json:"-"`
 	}
 
 	Agency struct {
-		ID          uint   `gorm:"primaryKey" json:"-"`
-		Name        string `gorm:"not null;type:varchar(150)" json:"name"`
-		Email       string `gorm:"not null;type:varchar(100)" json:"email"`
-		Description string `gorm:"not null;type:varchar(300)" json:"description"`
-		Address     string `gorm:"not null;type:varchar(250)" json:"address"`
-		Logo        string `gorm:"type:varchar(100)" json:"logo"`
+		ID          uint   `gorm:"column:id;primaryKey" json:"-"`
+		Name        string `gorm:"column:name;not null;type:varchar(150)" json:"name"`
+		Email       string `gorm:"column:email;not null;type:varchar(100)" json:"email"`
+		Description string `gorm:"column:description;not null;type:varchar(300)" json:"description"`
+		Address     string `gorm:"column:address;not null;type:varchar(250)" json:"address"`
+		Logo        string `gorm:"column:logo;type:varchar(100)" json:"logo"`
 
-		CreatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
-		UpdatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
+		CreatedAt time.Time `gorm:"column:created_at;not null;type:timestamptz" json:"-"`
+		UpdatedAt time.Time `gorm:"column:updated_at;not null;type:timestamptz" json:"-"`
 		DeletedAt gorm.DeletedAt
 
-		Staff []AgencyStaff `gorm:"foreignKey:agency_id;constraint:OnDelete:CASCADE" json:"staff,omitempty"`
+		Staff []Agent `gorm:"foreignKey:agency_id;constraint:OnDelete:CASCADE" json:"staff,omitempty"`
 	}
 
-	AgencyStaff struct {
-		ID       uint            `gorm:"primaryKey" json:"-"`
-		UserID   uint            `gorm:"not null;type:int8" json:"user_id"`
-		AgencyID uint            `gorm:"not null;type:int8" json:"agency_id"`
-		Name     string          `gorm:"not null;type:varchar(150)" json:"name"`
-		Photo    string          `gorm:"not null; type:varchar(100)" json:"photo"`
-		NID      string          `gorm:"not null;type:varchar(100)" json:"nid"`
-		Address  string          `gorm:"not null;type:varchar(250)" json:"address"`
-		Role     cdt.AgencyRole  `gorm:"not null;type:varchar(30)" json:"role"`
+	Agent struct {
+		ID       uint           `gorm:"column:id;primaryKey" json:"-"`
+		UserID   uint           `gorm:"column:user_id;not null;type:int8" json:"user_id"`
+		AgencyID uint           `gorm:"column:agency_id;not null;type:int8" json:"agency_id"`
+		Name     string         `gorm:"column:name;not null;type:varchar(150)" json:"name"`
+		Photo    string         `gorm:"column:photo;not null; type:varchar(100)" json:"photo"`
+		NID      string         `gorm:"column:nid;not null;type:varchar(100)" json:"nid"`
+		Address  string         `gorm:"column:address;not null;type:varchar(250)" json:"address"`
+		Role     cdt.AgencyRole `gorm:"column:role;not null;type:varchar(30)" json:"role"`
 
-		CreatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
-		UpdatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
+		CreatedAt time.Time `gorm:"column:created_at;not null;type:timestamptz" json:"-"`
+		UpdatedAt time.Time `gorm:"column:updated_at;not null;type:timestamptz" json:"-"`
 		DeletedAt gorm.DeletedAt
 
 		User User `gorm:"foreignKey:user_id" json:"-"`
 	}
 
 	TemporarySignupInfo struct {
-		ID     uint `gorm:"primaryKey" json:"-"`
-		UserID uint `gorm:"not null" json:"link_id"`
+		ID     uint `gorm:"column:id;primaryKey" json:"-"`
+		UserID uint `gorm:"column:user_id;not null" json:"user_id"`
 
 		// Agency Staff Info
-		StaffPhoto   string `gorm:"not null; type:varchar(100)" json:"staff_photo"`
-		StaffNID     string `gorm:"not null;type:varchar(100)" json:"staff_nid"`
-		StaffAddress string `gorm:"not null;type:varchar(250)" json:"staff_address"`
+		AgentPhoto   string `gorm:"column:agent_photo;not null; type:varchar(100)" json:"agent_photo"`
+		AgentNID     string `gorm:"column:agent_nid;not null;type:varchar(100)" json:"agent_nid"`
+		AgentAddress string `gorm:"column:agent_address;not null;type:varchar(250)" json:"agent_address"`
 
 		// Agency Info
-		AgencyName        string `gorm:"not null;type:varchar(150)" json:"agency_name"`
-		AgencyEmail       string `gorm:"not null;type:varchar(100)" json:"agency_email"`
-		AgencyDescription string `gorm:"not null;type:varchar(300)" json:"agency_description"`
-		AgencyAddress     string `gorm:"not null;type:varchar(250)" json:"agency_address"`
-		AgencyLogo        string `gorm:"type:varchar(100)" json:"agency_logo"`
+		AgencyName        string `gorm:"column:agency_name;not null;type:varchar(150)" json:"agency_name"`
+		AgencyEmail       string `gorm:"column:agency_email;not null;type:varchar(100)" json:"agency_email"`
+		AgencyDescription string `gorm:"column:agency_description;not null;type:varchar(300)" json:"agency_description"`
+		AgencyAddress     string `gorm:"column:agency_address;not null;type:varchar(250)" json:"agency_address"`
+		AgencyLogo        string `gorm:"column:agency_logo;type:varchar(100)" json:"agency_logo"`
 
-		CreatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
-		UpdatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
+		CreatedAt time.Time `gorm:"column:created_at;not null;type:timestamptz" json:"-"`
+		UpdatedAt time.Time `gorm:"column:updated_at;not null;type:timestamptz" json:"-"`
 
 		User User `gorm:"foreignKey:user_id" json:"-"`
 	}
@@ -102,8 +102,8 @@ func (a *Agency) TableName() string {
 	return "agencies"
 }
 
-func (as *AgencyStaff) TableName() string {
-	return "agency_staff"
+func (as *Agent) TableName() string {
+	return "agents"
 }
 
 func (tsi *TemporarySignupInfo) TableName() string {

--- a/model/user.go
+++ b/model/user.go
@@ -21,7 +21,7 @@ type (
 		DeletedAt gorm.DeletedAt
 	}
 
-	Traveller struct {
+	Customer struct {
 		ID      uint   `gorm:"primaryKey" json:"-"`
 		UserID  uint   `gorm:"not null;type:int8" json:"user_id"`
 		Name    string `gorm:"not null;type:varchar(150)" json:"name"`
@@ -35,7 +35,7 @@ type (
 		User User `gorm:"foreignKey:user_id" json:"-"`
 	}
 
-	Organization struct {
+	Agency struct {
 		ID          uint   `gorm:"primaryKey" json:"-"`
 		Name        string `gorm:"not null;type:varchar(150)" json:"name"`
 		Email       string `gorm:"not null;type:varchar(100)" json:"email"`
@@ -47,18 +47,18 @@ type (
 		UpdatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
 		DeletedAt gorm.DeletedAt
 
-		Agents []Agent `gorm:"foreignKey:organization_id;constraint:OnDelete:CASCADE" json:"agents,omitempty"`
+		Staff []AgencyStaff `gorm:"foreignKey:agency_id;constraint:OnDelete:CASCADE" json:"staff,omitempty"`
 	}
 
-	Agent struct {
-		ID             uint                      `gorm:"primaryKey" json:"-"`
-		UserID         uint                      `gorm:"not null;type:int8" json:"user_id"`
-		OrganizationID uint                      `gorm:"not null;type:int8" json:"organization_id"`
-		Name           string                    `gorm:"not null;type:varchar(150)" json:"name"`
-		Photo          string                    `gorm:"not null; type:varchar(100)" json:"photo"`
-		NID            string                    `gorm:"not null;type:varchar(100)" json:"nid"`
-		Address        string                    `gorm:"not null;type:varchar(250)" json:"address"`
-		Role           cdt.AgentOrganizationRole `gorm:"not null;type:varchar(30)" json:"role"`
+	AgencyStaff struct {
+		ID       uint            `gorm:"primaryKey" json:"-"`
+		UserID   uint            `gorm:"not null;type:int8" json:"user_id"`
+		AgencyID uint            `gorm:"not null;type:int8" json:"agency_id"`
+		Name     string          `gorm:"not null;type:varchar(150)" json:"name"`
+		Photo    string          `gorm:"not null; type:varchar(100)" json:"photo"`
+		NID      string          `gorm:"not null;type:varchar(100)" json:"nid"`
+		Address  string          `gorm:"not null;type:varchar(250)" json:"address"`
+		Role     cdt.AgencyRole  `gorm:"not null;type:varchar(30)" json:"role"`
 
 		CreatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
 		UpdatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
@@ -71,17 +71,17 @@ type (
 		ID     uint `gorm:"primaryKey" json:"-"`
 		UserID uint `gorm:"not null" json:"link_id"`
 
-		// Agent Info
-		AgentPhoto   string `gorm:"not null; type:varchar(100)" json:"agent_photo"`
-		AgentNID     string `gorm:"not null;type:varchar(100)" json:"agent_nid"`
-		AgentAddress string `gorm:"not null;type:varchar(250)" json:"agent_address"`
+		// Agency Staff Info
+		StaffPhoto   string `gorm:"not null; type:varchar(100)" json:"staff_photo"`
+		StaffNID     string `gorm:"not null;type:varchar(100)" json:"staff_nid"`
+		StaffAddress string `gorm:"not null;type:varchar(250)" json:"staff_address"`
 
-		// Organization Info
-		OrganizationName        string `gorm:"not null;type:varchar(150)" json:"organization_name"`
-		OrganizationEmail       string `gorm:"not null;type:varchar(100)" json:"organization_email"`
-		OrganizationDescription string `gorm:"not null;type:varchar(300)" json:"organization_description"`
-		OrganizationAddress     string `gorm:"not null;type:varchar(250)" json:"organization_address"`
-		OrganizationLogo        string `gorm:"type:varchar(100)" json:"organization_photo"`
+		// Agency Info
+		AgencyName        string `gorm:"not null;type:varchar(150)" json:"agency_name"`
+		AgencyEmail       string `gorm:"not null;type:varchar(100)" json:"agency_email"`
+		AgencyDescription string `gorm:"not null;type:varchar(300)" json:"agency_description"`
+		AgencyAddress     string `gorm:"not null;type:varchar(250)" json:"agency_address"`
+		AgencyLogo        string `gorm:"type:varchar(100)" json:"agency_logo"`
 
 		CreatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
 		UpdatedAt time.Time `gorm:"not null;type:timestamptz" json:"-"`
@@ -94,16 +94,16 @@ func (u *User) TableName() string {
 	return "users"
 }
 
-func (t *Traveller) TableName() string {
-	return "travellers"
+func (c *Customer) TableName() string {
+	return "customers"
 }
 
-func (o *Organization) TableName() string {
-	return "organizations"
+func (a *Agency) TableName() string {
+	return "agencies"
 }
 
-func (a *Agent) TableName() string {
-	return "agents"
+func (as *AgencyStaff) TableName() string {
+	return "agency_staff"
 }
 
 func (tsi *TemporarySignupInfo) TableName() string {


### PR DESCRIPTION
- Simplify AgencyRole from admin/representative to owner/staff
- Update AgencyRole.IsValid() method to validate new constants
- Fix typo: "dopped" -> "dropped" in migration down command
- Fix typo: "Cant't" -> "Can't" in migration root command

BREAKING CHANGE: AgencyRole constants changed from admin/representative to owner/staff